### PR TITLE
Expose WCR Quiz settings in separate admin tab

### DIFF
--- a/wcr-quiz/wcr-quiz.php
+++ b/wcr-quiz/wcr-quiz.php
@@ -66,7 +66,7 @@ function wcrq_register_settings() {
 add_action('admin_init', 'wcrq_register_settings');
 
 function wcrq_settings_page() {
-    add_options_page('WCR Quiz', 'WCR Quiz', 'manage_options', 'wcrq', 'wcrq_settings_page_html');
+    add_menu_page('WCR Quiz', 'WCR Quiz', 'manage_options', 'wcrq', 'wcrq_settings_page_html', 'dashicons-welcome-learn-more', 20);
 }
 add_action('admin_menu', 'wcrq_settings_page');
 


### PR DESCRIPTION
## Summary
- Display WCR Quiz settings as a top-level admin menu instead of under Settings

## Testing
- `php -l wcr-quiz.php`


------
https://chatgpt.com/codex/tasks/task_e_689df56d5c5483209cbf6bc0598b0348