### PR TITLE
Display participant code after approval

### DIFF
--- a/wcr-quiz/wcr-quiz.php
+++ b/wcr-quiz/wcr-quiz.php
@@ -107,7 +107,8 @@ function wcrq_registrations_page_html() {
         if ($participant) {
             wp_mail($participant->email, __('Kod dostępu do quizu', 'wcrq'), sprintf(__('Twój kod: %s', 'wcrq'), $code));
         }
-        echo '<div class="updated"><p>' . __('Użytkownik zaakceptowany.', 'wcrq') . '</p></div>';
+        // Show generated code in the admin notice so it's clear it was assigned.
+        echo '<div class="updated"><p>' . sprintf(__('Użytkownik zaakceptowany. Kod: %s', 'wcrq'), esc_html($code)) . '</p></div>';
     }
     $rows = $wpdb->get_results("SELECT * FROM $table ORDER BY created DESC");
     echo '<div class="wrap"><h1>' . esc_html(__('Rejestracje', 'wcrq')) . '</h1>';


### PR DESCRIPTION
## Summary
- Show generated quiz access code in admin notice when a participant is approved

## Testing
- `php -l wcr-quiz/wcr-quiz.php`


------
https://chatgpt.com/codex/tasks/task_e_689dfa806ca08320ace6ba04e5206261