### PR TITLE
feat: enhance registration workflow with styled forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ W panelu administracyjnym w sekcji **Ustawienia → WCR Quiz** ustaw:
 - czy wynik ma być pokazany uczestnikowi.
 
 ## Shortcody
-- `[wcr_registration]` – formularz rejestracji (imię, e‑mail, login i hasło).
-- `[wcr_quiz]` – logowanie i udział w quizie.
+- `[wcr_registration]` – formularz rejestracji (nazwa szkoły, imię i nazwisko ucznia, klasa, e‑mail). Login i hasło generowane są automatycznie i wysyłane na e‑mail.
+- `[wcr_quiz]` – logowanie (login oraz hasło) i udział w quizie.
 
 Wersje testowane: WordPress 5.7.2, PHP 7.4.33.

--- a/wcr-quiz/assets/css/style.css
+++ b/wcr-quiz/assets/css/style.css
@@ -1,0 +1,43 @@
+.wcrq-registration, .wcrq-login, .wcrq-quiz {
+    background: #f0fdf4;
+    border: 2px solid #16a34a;
+    border-radius: 8px;
+    padding: 1.5rem;
+    max-width: 500px;
+    margin: 1rem auto;
+    font-family: Arial, sans-serif;
+}
+
+.wcrq-registration label, .wcrq-login label {
+    display: block;
+    margin-bottom: 0.5rem;
+    color: #166534;
+    font-weight: 600;
+}
+
+.wcrq-registration input,
+.wcrq-login input {
+    width: 100%;
+    padding: 0.5rem;
+    margin-top: 0.25rem;
+    border: 1px solid #a3d9a5;
+    border-radius: 4px;
+    box-sizing: border-box;
+}
+
+.wcrq-registration button,
+.wcrq-login button,
+.wcrq-quiz button {
+    background: #16a34a;
+    color: #fff;
+    padding: 0.5rem 1rem;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.wcrq-registration button:hover,
+.wcrq-login button:hover,
+.wcrq-quiz button:hover {
+    background: #15803d;
+}


### PR DESCRIPTION
## Summary
- add green-themed CSS and enqueue styles for frontend forms
- capture school, student, class and email in registration, auto-generate login credentials and notify via email
- list registrations with credentials and timestamps in admin panel and support login using generated data

## Testing
- `php -l wcr-quiz/wcr-quiz.php`

------
https://chatgpt.com/codex/tasks/task_e_68bdb0288c3c83208e2d064d1f50ed7c