### PR TITLE
Ensure quiz tables exist on plugin load

### DIFF
--- a/wcr-quiz/wcr-quiz.php
+++ b/wcr-quiz/wcr-quiz.php
@@ -76,6 +76,18 @@ function wcrq_maybe_add_blocked_column() {
 }
 add_action('plugins_loaded', 'wcrq_maybe_add_blocked_column');
 
+function wcrq_maybe_create_tables() {
+    global $wpdb;
+    $participants_table = $wpdb->prefix . 'wcrq_participants';
+    $results_table = $wpdb->prefix . 'wcrq_results';
+    $p_exists = $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $participants_table));
+    $r_exists = $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $results_table));
+    if ($p_exists !== $participants_table || $r_exists !== $results_table) {
+        wcrq_activate();
+    }
+}
+add_action('plugins_loaded', 'wcrq_maybe_create_tables');
+
 // Settings page
 function wcrq_register_settings() {
     register_setting('wcrq_settings', 'wcrq_settings');


### PR DESCRIPTION
## Summary
- Ensure participant and result tables are created if they are missing

## Testing
- `php -l wcr-quiz/wcr-quiz.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdb8b0f2ec8320a36cd89cc106f23e