### PR TITLE
Add registration validations and injection detection

### DIFF
--- a/wcr-quiz/assets/js/registration.js
+++ b/wcr-quiz/assets/js/registration.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.querySelector('form.wcrq-registration');
+  if (!form) return;
+  form.addEventListener('submit', (e) => {
+    const inputs = ['wcrq_school', 'wcrq_name', 'wcrq_class', 'wcrq_email'].map(name => form.querySelector(`[name="${name}"]`));
+    const pattern = /<|>|script|select|insert|delete|update|drop|union|--/i;
+    for (const input of inputs) {
+      if (pattern.test(input.value)) {
+        e.preventDefault();
+        alert('nie mozna psuć');
+        return false;
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- enforce maximum lengths and server-side checks for registration fields
- block SQL/JS/HTML injection attempts and duplicated emails with clear messages
- add client-side script to reject suspicious input before submission

## Testing
- `php -l wcr-quiz.php`
- `node -e "require('fs').readFileSync('assets/js/registration.js','utf8')"`


------
https://chatgpt.com/codex/tasks/task_e_68bdc16f8fa88320998e9246cb750482