### PR TITLE
Add image and preview support for quiz questions

### DIFF
--- a/wcr-quiz/assets/css/style.css
+++ b/wcr-quiz/assets/css/style.css
@@ -55,3 +55,10 @@
     color: #555;
     font-size: 0.9rem;
 }
+
+/* Images inside questions */
+.wcrq-question-image {
+    max-width: 100%;
+    height: auto;
+    margin-bottom: 1rem;
+}

--- a/wcr-quiz/assets/js/questions-builder.js
+++ b/wcr-quiz/assets/js/questions-builder.js
@@ -1,10 +1,20 @@
 jQuery(function($){
   const container = $('#wcrq-questions-builder');
   const input = $('#wcrq_questions_input');
+
   function addQuestion(q){
     const index = container.children('.wcrq-question').length;
     const div = $('<div class="wcrq-question">');
+
+    // Question text
     div.append('<p><label>Pytanie: <input type="text" class="wcrq-q" value="'+(q.question||'')+'"></label></p>');
+
+    // Image picker
+    const imgUrl = q.image || '';
+    const imgTag = imgUrl ? '<img src="'+imgUrl+'" style="max-width:150px;height:auto;" />' : '';
+    div.append('<div class="wcrq-image">'+imgTag+'<p><button type="button" class="button wcrq-select-image">Wybierz grafikę</button> <button type="button" class="button wcrq-remove-image">Usuń</button></p><input type="hidden" class="wcrq-img" value="'+imgUrl+'"></div>');
+
+    // Answers
     const answersDiv = $('<div class="wcrq-answers"><p>Odpowiedzi:</p></div>');
     for(let i=0;i<4;i++){
       const ans = q.answers && q.answers[i] ? q.answers[i] : '';
@@ -12,9 +22,13 @@ jQuery(function($){
       answersDiv.append('<p><label><input type="radio" name="correct'+index+'" value="'+i+'" '+checked+'> <input type="text" class="wcrq-a" value="'+ans+'"></label></p>');
     }
     div.append(answersDiv);
-    div.append('<p><button type="button" class="button wcrq-remove">Usuń</button></p>');
+
+    // Action buttons
+    div.append('<p><button type="button" class="button wcrq-preview">Podgląd</button> <button type="button" class="button wcrq-remove">Usuń</button></p><div class="wcrq-preview-area" style="display:none;"></div>');
+
     container.append(div);
   }
+
   function collect(){
     const arr = [];
     container.children('.wcrq-question').each(function(){
@@ -22,15 +36,66 @@ jQuery(function($){
       const answers = [];
       $(this).find('.wcrq-a').each(function(){ answers.push($(this).val()); });
       const correct = parseInt($(this).find('input[type=radio]:checked').val()) || 0;
-      arr.push({question:qText, answers:answers, correct:correct});
+      const img = $(this).find('.wcrq-img').val();
+      arr.push({question:qText, answers:answers, correct:correct, image:img});
     });
     input.val(JSON.stringify(arr));
   }
-  $('#wcrq_add_question').on('click', function(){ addQuestion({}); });
+
+  // Remove question
   container.on('click', '.wcrq-remove', function(){ $(this).closest('.wcrq-question').remove(); });
+
+  // Select image using WP media library
+  let frame;
+  container.on('click', '.wcrq-select-image', function(e){
+    e.preventDefault();
+    const holder = $(this).closest('.wcrq-image');
+    if(frame){ frame.close(); }
+    frame = wp.media({
+      title: 'Wybierz grafikę',
+      button: { text: 'Użyj' },
+      multiple: false
+    });
+    frame.on('select', function(){
+      const attachment = frame.state().get('selection').first().toJSON();
+      holder.find('.wcrq-img').val(attachment.url);
+      holder.find('img').remove();
+      holder.prepend('<img src="'+attachment.url+'" style="max-width:150px;height:auto;" />');
+    });
+    frame.open();
+  });
+
+  // Remove image
+  container.on('click', '.wcrq-remove-image', function(){
+    const holder = $(this).closest('.wcrq-image');
+    holder.find('.wcrq-img').val('');
+    holder.find('img').remove();
+  });
+
+  // Preview question
+  container.on('click', '.wcrq-preview', function(){
+    const wrap = $(this).closest('.wcrq-question');
+    const qText = wrap.find('.wcrq-q').val();
+    const img = wrap.find('.wcrq-img').val();
+    const answers = [];
+    wrap.find('.wcrq-a').each(function(){ answers.push($(this).val()); });
+    let html = '<p>'+qText+'</p>';
+    if(img){ html += '<p><img src="'+img+'" style="max-width:150px;height:auto;" /></p>'; }
+    answers.forEach(function(a){ html += '<label><input type="radio" disabled> '+a+'</label><br />'; });
+    const prev = wrap.find('.wcrq-preview-area');
+    prev.html(html).toggle();
+  });
+
+  // Collect data on form submit
   $('form').on('submit', collect);
+
+  // Load existing questions
   let existing = [];
   try{ existing = JSON.parse(input.val()); }catch(e){}
   if(Array.isArray(existing)) existing.forEach(addQuestion);
+
+  // Add button after container and bind handler
   container.after('<p><button type="button" class="button" id="wcrq_add_question">Dodaj pytanie</button></p>');
+  $(document).on('click', '#wcrq_add_question', function(){ addQuestion({}); });
 });
+

--- a/wcr-quiz/wcr-quiz.php
+++ b/wcr-quiz/wcr-quiz.php
@@ -259,7 +259,15 @@ function wcrq_field_show_results() {
 
 function wcrq_admin_scripts($hook) {
     if (isset($_GET['page']) && $_GET['page'] === 'wcrq') {
-        wp_enqueue_script('wcrq-questions-builder', plugins_url('assets/js/questions-builder.js', __FILE__), ['jquery'], '0.1', true);
+        // Media is required for adding images to questions
+        wp_enqueue_media();
+        wp_enqueue_script(
+            'wcrq-questions-builder',
+            plugins_url('assets/js/questions-builder.js', __FILE__),
+            ['jquery'],
+            '0.2',
+            true
+        );
     }
 }
 add_action('admin_enqueue_scripts', 'wcrq_admin_scripts');
@@ -425,7 +433,11 @@ function wcrq_quiz_shortcode() {
     wp_enqueue_script('wcrq-quiz', plugins_url('assets/js/quiz.js', __FILE__), [], '0.1', true);
     $out = '<form method="post" class="wcrq-quiz" data-duration="' . intval($remaining) . '">' . wp_nonce_field('wcrq_quiz', 'wcrq_quiz_nonce', true, false);
     foreach ($questions as $idx => $q) {
-        $out .= '<div class="wcrq-question"><p>' . esc_html($q['question']) . '</p>';
+        $out .= '<div class="wcrq-question">';
+        $out .= '<p>' . esc_html($q['question']) . '</p>';
+        if (!empty($q['image'])) {
+            $out .= '<p><img src="' . esc_url($q['image']) . '" alt="" class="wcrq-question-image" /></p>';
+        }
         foreach ($q['answers'] as $a_idx => $answer) {
             $name = 'q' . $idx;
             $out .= '<label><input type="radio" name="' . esc_attr($name) . '" value="' . $a_idx . '"> ' . esc_html($answer) . '</label><br />';


### PR DESCRIPTION
## Summary
- allow admin to add images to questions with live preview
- render question images on quiz frontend and style them

## Testing
- `php -l wcr-quiz/wcr-quiz.php`
- `node --check wcr-quiz/assets/js/questions-builder.js`


------
https://chatgpt.com/codex/tasks/task_e_68bdd312e0e48320a0c85aac027c9091