### PR TITLE
Add quiz scheduling controls and tabbed navigation

### DIFF
--- a/wcr-quiz/assets/css/style.css
+++ b/wcr-quiz/assets/css/style.css
@@ -31,7 +31,8 @@
 
 .wcrq-registration button,
 .wcrq-login button,
-.wcrq-quiz button {
+.wcrq-quiz button,
+.wcrq-start button {
     background: #16a34a;
     color: #fff;
     padding: 1rem 2rem;
@@ -43,7 +44,8 @@
 
 .wcrq-registration button:hover,
 .wcrq-login button:hover,
-.wcrq-quiz button:hover {
+.wcrq-quiz button:hover,
+.wcrq-start button:hover {
     background: #15803d;
 }
 
@@ -61,4 +63,90 @@
     max-width: 100%;
     height: auto;
     margin-bottom: 1rem;
+}
+
+.wcrq-timer {
+    font-weight: 700;
+    font-size: 1.5rem;
+    margin-bottom: 1.5rem;
+    text-align: right;
+}
+
+.wcrq-question-tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.wcrq-question-tab {
+    background: #dcfce7;
+    border: 1px solid #16a34a;
+    border-radius: 4px;
+    color: #166534;
+    cursor: pointer;
+    padding: 0.5rem 1rem;
+    transition: background 0.2s ease;
+}
+
+.wcrq-question-tab.is-active {
+    background: #16a34a;
+    color: #fff;
+}
+
+.wcrq-question-tab.is-answered:not(.is-active) {
+    border-style: dashed;
+}
+
+.wcrq-question-tab[disabled] {
+    cursor: not-allowed;
+    opacity: 0.6;
+}
+
+.wcrq-quiz:not(.wcrq-no-js) .wcrq-question {
+    display: none;
+}
+
+.wcrq-quiz:not(.wcrq-no-js) .wcrq-question.is-active {
+    display: block;
+}
+
+.wcrq-question-title {
+    font-weight: 600;
+    margin-bottom: 1rem;
+}
+
+.wcrq-answer {
+    display: block;
+    margin-bottom: 0.75rem;
+}
+
+.wcrq-question-nav {
+    display: flex;
+    gap: 1rem;
+    margin-top: 2rem;
+}
+
+.wcrq-question-nav button {
+    flex: 1 1 auto;
+}
+
+.wcrq-pre-quiz {
+    background: #f0fdf4;
+    border: 2px solid #16a34a;
+    border-radius: 8px;
+    padding: 2rem;
+    max-width: 700px;
+    margin: 2rem auto;
+    font-family: Arial, sans-serif;
+}
+
+.wcrq-navigation-warning {
+    font-weight: 600;
+    color: #dc2626;
+}
+
+.wcrq-no-js .wcrq-question-tabs,
+.wcrq-no-js .wcrq-question-nav {
+    display: none;
 }

--- a/wcr-quiz/assets/js/quiz.js
+++ b/wcr-quiz/assets/js/quiz.js
@@ -1,22 +1,112 @@
 document.addEventListener('DOMContentLoaded', function() {
   var form = document.querySelector('.wcrq-quiz');
   if (!form) return;
-  var seconds = parseInt(form.dataset.duration, 10);
-  if (!seconds) return;
-  var end = Date.now() + seconds * 1000;
-  var timer = document.createElement('div');
-  timer.className = 'wcrq-timer';
-  form.insertBefore(timer, form.firstChild);
-  function tick() {
-    var remain = Math.max(0, Math.round((end - Date.now()) / 1000));
-    var m = Math.floor(remain / 60);
-    var s = ('0' + (remain % 60)).slice(-2);
-    timer.textContent = m + ':' + s;
-    if (remain <= 0) {
-      form.submit();
-    } else {
-      setTimeout(tick, 1000);
+  form.classList.remove('wcrq-no-js');
+
+  var seconds = parseInt(form.dataset.duration || '0', 10);
+  if (!isNaN(seconds) && seconds > 0) {
+    var end = Date.now() + seconds * 1000;
+    var timer = document.createElement('div');
+    timer.className = 'wcrq-timer';
+    form.insertBefore(timer, form.firstChild);
+    var tick = function() {
+      var remain = Math.max(0, Math.round((end - Date.now()) / 1000));
+      var m = Math.floor(remain / 60);
+      var s = ('0' + (remain % 60)).slice(-2);
+      timer.textContent = m + ':' + s;
+      if (remain <= 0) {
+        form.submit();
+      } else {
+        setTimeout(tick, 1000);
+      }
+    };
+    tick();
+  }
+
+  var questions = Array.from(form.querySelectorAll('.wcrq-question'));
+  if (!questions.length) return;
+
+  var tabs = Array.from(form.querySelectorAll('.wcrq-question-tab'));
+  var prevBtn = form.querySelector('.wcrq-prev');
+  var nextBtn = form.querySelector('.wcrq-next');
+  var submitBtn = form.querySelector('.wcrq-submit');
+  var allowNavigation = form.dataset.allowNavigation === '1';
+  var current = 0;
+
+  function updateButtons() {
+    if (prevBtn) {
+      if (allowNavigation) {
+        prevBtn.style.display = '';
+        prevBtn.disabled = current === 0;
+      } else {
+        prevBtn.style.display = 'none';
+      }
+    }
+    if (nextBtn) {
+      nextBtn.style.display = current >= questions.length - 1 ? 'none' : '';
+    }
+    if (submitBtn) {
+      submitBtn.style.display = current === questions.length - 1 ? '' : 'none';
     }
   }
-  tick();
+
+  function syncTabState(index) {
+    if (!tabs.length) return;
+    tabs.forEach(function(tab, i) {
+      tab.classList.toggle('is-active', i === index);
+      if (!allowNavigation) {
+        tab.disabled = i !== index;
+      }
+    });
+  }
+
+  function markAnswered(index) {
+    if (!tabs.length) return;
+    var answered = !!questions[index].querySelector('input[type="radio"]:checked');
+    tabs[index].classList.toggle('is-answered', answered);
+  }
+
+  function setActive(index) {
+    if (index < 0 || index >= questions.length) return;
+    current = index;
+    questions.forEach(function(q, i) {
+      q.classList.toggle('is-active', i === index);
+    });
+    syncTabState(index);
+    updateButtons();
+  }
+
+  questions.forEach(function(question, index) {
+    question.addEventListener('change', function() {
+      markAnswered(index);
+    });
+  });
+
+  questions.forEach(function(_, index) {
+    markAnswered(index);
+  });
+
+  if (allowNavigation) {
+    if (prevBtn) {
+      prevBtn.addEventListener('click', function() {
+        setActive(current - 1);
+      });
+    }
+    tabs.forEach(function(tab) {
+      tab.addEventListener('click', function() {
+        var idx = parseInt(tab.dataset.index || '0', 10);
+        if (!isNaN(idx)) {
+          setActive(idx);
+        }
+      });
+    });
+  }
+
+  if (nextBtn) {
+    nextBtn.addEventListener('click', function() {
+      setActive(current + 1);
+    });
+  }
+
+  setActive(0);
 });


### PR DESCRIPTION
## Summary
- move the question builder to its own submenu and extend quiz settings with scheduling, messaging, and navigation toggles
- update the quiz shortcode to honour the new options, randomise questions on demand, and present one question per tab with optional backtracking
- style and script the new tabbed quiz flow with timers, navigation controls, and a no-JS fallback

## Testing
- php -l wcr-quiz/wcr-quiz.php

------
https://chatgpt.com/codex/tasks/task_e_68cac992b23c8320ba83f29917433408