### PR TITLE
Add quiz countdown and improve question management

### DIFF
--- a/wcr-quiz/assets/css/style.css
+++ b/wcr-quiz/assets/css/style.css
@@ -150,3 +150,18 @@
 .wcrq-no-js .wcrq-question-nav {
     display: none;
 }
+
+.wcrq-countdown {
+    margin-top: 1.5rem;
+    font-weight: 700;
+    font-size: 1.5rem;
+    text-align: center;
+    color: #166534;
+}
+
+.wcrq-timezone-note {
+    margin-top: 1rem;
+    font-size: 0.95rem;
+    color: #555;
+    text-align: center;
+}

--- a/wcr-quiz/assets/js/countdown.js
+++ b/wcr-quiz/assets/js/countdown.js
@@ -1,0 +1,47 @@
+(function(){
+  function format(seconds){
+    var total = Math.max(0, seconds);
+    var hours = Math.floor(total / 3600);
+    var minutes = Math.floor((total % 3600) / 60);
+    var secs = total % 60;
+    var parts = [hours, minutes, secs].map(function(part){
+      return String(part).padStart(2, '0');
+    });
+    return parts.join(':');
+  }
+
+  function initCountdown(el){
+    var secondsAttr = el.getAttribute('data-countdown-seconds');
+    if(!secondsAttr){
+      return;
+    }
+    var remaining = parseInt(secondsAttr, 10);
+    if(isNaN(remaining)){
+      return;
+    }
+    var timeEl = el.querySelector('.wcrq-countdown-time');
+    if(!timeEl){
+      timeEl = document.createElement('span');
+      timeEl.className = 'wcrq-countdown-time';
+      el.appendChild(timeEl);
+    }
+
+    function tick(){
+      timeEl.textContent = format(remaining);
+      if(remaining <= 0){
+        clearInterval(timer);
+        el.classList.add('wcrq-countdown-finished');
+        return;
+      }
+      remaining -= 1;
+    }
+
+    tick();
+    var timer = setInterval(tick, 1000);
+  }
+
+  document.addEventListener('DOMContentLoaded', function(){
+    var countdowns = document.querySelectorAll('.wcrq-countdown[data-countdown-seconds]');
+    countdowns.forEach(initCountdown);
+  });
+})();

--- a/wcr-quiz/assets/js/questions-builder.js
+++ b/wcr-quiz/assets/js/questions-builder.js
@@ -1,6 +1,13 @@
 jQuery(function($){
   const container = $('#wcrq-questions-builder');
   const input = $('#wcrq_questions_input');
+  const fallback = $('.wcrq-questions-fallback');
+
+  if(!container.length || !input.length){
+    return;
+  }
+
+  fallback.hide();
 
   function addQuestion(q){
     const index = container.children('.wcrq-question').length;


### PR DESCRIPTION
## Summary
- show a countdown until the quiz opens and clarify the Europe/Warsaw timezone on the frontend and in settings
- sanitize quiz settings while keeping question data and add a no-JS form for managing questions
- hide the fallback form when the JS builder loads and style the countdown block

## Testing
- php -l wcr-quiz/wcr-quiz.php

------
https://chatgpt.com/codex/tasks/task_e_68cacdaf99a8832087df298481070c61