### PR TITLE
Fix fallback question saving without JS

### DIFF
--- a/wcr-quiz/wcr-quiz.php
+++ b/wcr-quiz/wcr-quiz.php
@@ -160,7 +160,7 @@ function wcrq_sanitize_settings($input) {
 
     $questions = [];
 
-    if (!empty($input['questions'])) {
+    if (isset($input['questions'])) {
         $raw = wp_unslash($input['questions']);
         $decoded = json_decode($raw, true);
         if (is_array($decoded)) {
@@ -171,7 +171,9 @@ function wcrq_sanitize_settings($input) {
                 }
             }
         }
-    } elseif (!empty($input['questions_nojs']) && is_array($input['questions_nojs'])) {
+    }
+
+    if (empty($questions) && !empty($input['questions_nojs']) && is_array($input['questions_nojs'])) {
         foreach ($input['questions_nojs'] as $question) {
             $prepared = wcrq_prepare_question_data($question);
             if ($prepared) {


### PR DESCRIPTION
## Summary
- ensure questions submitted through the no-JS fallback form are saved
- fall back to parsing the non-JavaScript fields when the visual builder payload is empty

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cad520b7508320acfde130d758b2f4