### PR TITLE
Refactor quiz question editor UI

### DIFF
--- a/wcr-quiz/assets/css/admin.css
+++ b/wcr-quiz/assets/css/admin.css
@@ -1,0 +1,101 @@
+#wcrq-questions-app {
+    margin-top: 1rem;
+}
+
+#wcrq-questions-app .wcrq-question-item {
+    border: 1px solid #ccd0d4;
+    border-radius: 6px;
+    padding: 1.25rem 1.5rem;
+    margin-bottom: 1.25rem;
+    background: #fff;
+}
+
+#wcrq-questions-app .wcrq-question-item legend {
+    font-weight: 600;
+    font-size: 1rem;
+    padding: 0 0.5rem;
+}
+
+.wcrq-question-fields {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin: 0 0 1rem;
+}
+
+.wcrq-question-fields .wcrq-field {
+    flex: 1 1 260px;
+    margin: 0;
+}
+
+.wcrq-field-image {
+    max-width: 320px;
+}
+
+.wcrq-image-preview {
+    margin-top: 0.5rem;
+    min-height: 20px;
+}
+
+.wcrq-image-preview img {
+    max-width: 160px;
+    height: auto;
+    border: 1px solid #ccd0d4;
+    padding: 4px;
+    background: #f8f9fa;
+    display: block;
+}
+
+.wcrq-image-actions {
+    margin-top: 0.5rem;
+}
+
+.wcrq-answers {
+    margin-top: 1rem;
+}
+
+.wcrq-answer-row {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.wcrq-answer-row input[type="text"] {
+    flex: 1 1 auto;
+}
+
+.wcrq-question-actions {
+    margin-top: 1rem;
+    display: flex;
+    gap: 0.5rem;
+}
+
+.wcrq-question-actions .wcrq-remove[disabled] {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.wcrq-preview-area {
+    margin-top: 1rem;
+    padding: 0.75rem 1rem;
+    background: #f6f7f7;
+    border-left: 3px solid #2271b1;
+}
+
+.wcrq-questions-fallback {
+    margin-top: 2rem;
+    border-top: 1px solid #ccd0d4;
+    padding-top: 1.5rem;
+}
+
+.wcrq-questions-fallback .wcrq-question-fallback {
+    border: 1px dashed #ccd0d4;
+    border-radius: 6px;
+    padding: 1rem 1.25rem;
+    margin-bottom: 1rem;
+    background: #fff;
+}
+
+.wcrq-questions-fallback .wcrq-question-fallback legend {
+    font-weight: 600;
+}

--- a/wcr-quiz/assets/js/questions-builder.js
+++ b/wcr-quiz/assets/js/questions-builder.js
@@ -1,42 +1,124 @@
 /**
- * Visual builder for quiz questions in the admin panel.
+ * Admin builder for quiz questions.
  */
 jQuery(function ($) {
-  const container = $('#wcrq-questions-builder');
-  const input = $('#wcrq_questions_input');
-  const fallback = $('.wcrq-questions-fallback');
-
-  if (!container.length || !input.length) {
+  const app = $('#wcrq-questions-app');
+  if (!app.length) {
     return;
   }
 
-  const form = container.closest('form');
-  let mediaFrame = null;
-  let counter = 0;
-  const hasI18n = typeof window !== 'undefined' && window.wp && window.wp.i18n && typeof window.wp.i18n.__ === 'function';
+  const list = app.find('.wcrq-question-list');
+  const fallback = $('.wcrq-questions-fallback');
+  const addButton = $('#wcrq_add_question');
+  const templateElement = $('#wcrq-question-template');
+  const templateHtml = templateElement.length ? templateElement.html().trim() : '';
+  const form = app.closest('form');
+  const hasI18n =
+    typeof window !== 'undefined' &&
+    window.wp &&
+    window.wp.i18n &&
+    typeof window.wp.i18n.__ === 'function';
 
   function __(text) {
     return hasI18n ? window.wp.i18n.__(text, 'wcrq') : text;
   }
 
-  fallback.hide();
+  if (!templateHtml) {
+    return;
+  }
 
-  function ensureAnswersArray(value) {
-    const answers = Array.isArray(value) ? value.slice(0, 4) : [];
+  if (fallback.length) {
+    fallback.hide();
+  }
+
+  let mediaFrame = null;
+
+  function escapeHtml(value) {
+    return $('<div>').text(value || '').html();
+  }
+
+  function getBlankQuestion() {
+    return {
+      question: '',
+      answers: ['', '', '', ''],
+      correct: 0,
+      image: '',
+    };
+  }
+
+  function ensureAnswers(values) {
+    const answers = Array.isArray(values) ? values.slice(0, 4) : [];
     while (answers.length < 4) {
       answers.push('');
     }
     return answers;
   }
 
-  function escapeHtml(value) {
-    return $('<div>').text(value || '').html();
+  function updateRemoveState() {
+    const items = list.children('.wcrq-question-item');
+    const disableRemove = items.length <= 1;
+    items.each(function () {
+      $(this)
+        .find('.wcrq-remove')
+        .prop('disabled', disableRemove);
+    });
   }
 
-  function nextKey() {
-    const key = counter;
-    counter += 1;
-    return key;
+  function refreshIndices() {
+    list.children('.wcrq-question-item').each(function (index) {
+      const item = $(this);
+      item.attr('data-index', index);
+      item.find('.wcrq-question-number').text(index + 1);
+      item.find('[data-name-template]').each(function () {
+        const field = $(this);
+        const templateName = field.data('nameTemplate');
+        if (templateName) {
+          field.attr('name', templateName.replace(/__index__/g, index));
+        }
+      });
+    });
+    updateRemoveState();
+  }
+
+  function setQuestionValues(item, data) {
+    const question = data || getBlankQuestion();
+    const answers = ensureAnswers(question.answers);
+
+    item.find('.wcrq-q').val(question.question || '');
+    item.find('.wcrq-img').val(question.image || '');
+
+    const preview = item.find('.wcrq-image-preview');
+    preview.empty();
+    if (question.image) {
+      preview.append(
+        $('<img>', {
+          src: question.image,
+          alt: '',
+        }),
+      );
+    }
+
+    item.find('.wcrq-a').each(function (idx) {
+      $(this).val(answers[idx] || '');
+    });
+
+    const correct =
+      typeof question.correct === 'number'
+        ? question.correct
+        : parseInt(question.correct, 10) || 0;
+    item.find('.wcrq-correct').each(function () {
+      const radio = $(this);
+      radio.prop('checked', parseInt(radio.val(), 10) === correct);
+    });
+  }
+
+  function createQuestion(data) {
+    const element = $(templateHtml);
+    element.removeClass('wcrq-question-item-template');
+    setQuestionValues(element, data);
+    list.append(element);
+    refreshIndices();
+    return element;
   }
 
   function getQuestionData(wrapper) {
@@ -45,120 +127,104 @@ jQuery(function ($) {
       answers.push($(this).val());
     });
     return {
-      key: wrapper.data('key'),
       question: wrapper.find('.wcrq-q').val(),
       image: wrapper.find('.wcrq-img').val(),
       answers,
-      correct: parseInt(wrapper.find('input[type=radio]:checked').val(), 10) || 0,
+      correct: parseInt(wrapper.find('.wcrq-correct:checked').val(), 10) || 0,
     };
   }
 
-  function collect() {
-    const collected = [];
-    container.children('.wcrq-question').each(function () {
-      const question = getQuestionData($(this));
-      collected.push({
-        question: question.question,
-        answers: ensureAnswersArray(question.answers),
-        correct: question.correct,
-        image: question.image,
-      });
-    });
-    input.val(JSON.stringify(collected));
+  function clearQuestion(wrapper) {
+    setQuestionValues(wrapper, getBlankQuestion());
+    wrapper.find('.wcrq-preview-area').hide().empty();
   }
 
-  function snapshotQuestions() {
-    const questions = [];
-    container.children('.wcrq-question').each(function () {
-      questions.push(getQuestionData($(this)));
+  function renderPreview(wrapper) {
+    const data = getQuestionData(wrapper);
+    const preview = wrapper.find('.wcrq-preview-area');
+    let html = '';
+
+    if (data.question) {
+      html += '<p><strong>' + escapeHtml(data.question) + '</strong></p>';
+    }
+
+    if (data.image) {
+      html +=
+        '<p><img src="' +
+        escapeHtml(data.image) +
+        '" alt="" style="max-width:150px;height:auto;" /></p>';
+    }
+
+    data.answers.forEach(function (answer, index) {
+      if (!answer) {
+        return;
+      }
+      const mark = data.correct === index ? ' <em>(' + __('prawidłowa') + ')</em>' : '';
+      html +=
+        '<p><label><input type="radio" disabled> ' +
+        escapeHtml(answer) +
+        mark +
+        '</label></p>';
     });
-    return questions;
+
+    preview.html(html || '<p>' + __('Brak danych do podglądu.') + '</p>');
+    preview.toggle();
   }
 
-  function renderQuestion(question) {
-    const key = typeof question.key === 'number' ? question.key : nextKey();
-    const answers = ensureAnswersArray(question.answers);
+  addButton.on('click', function (event) {
+    event.preventDefault();
+    const element = createQuestion(getBlankQuestion());
+    element.find('.wcrq-q').trigger('focus');
+  });
 
-    const wrapper = $('<div class="wcrq-question">').attr('data-key', key);
-    const headingNumber = container.children('.wcrq-question').length + 1;
-    const heading = $('<h3 class="wcrq-question-heading">').text(`${__('Pytanie')} ${headingNumber}`);
-    wrapper.append(heading);
+  list.on('click', '.wcrq-remove', function (event) {
+    event.preventDefault();
+    const wrapper = $(this).closest('.wcrq-question-item');
+    const items = list.children('.wcrq-question-item');
+    if (items.length <= 1) {
+      clearQuestion(wrapper);
+      return;
+    }
+    wrapper.remove();
+    refreshIndices();
+  });
 
-    const questionRow = $('<p class="wcrq-question-row">');
-    const questionLabel = $('<label class="wcrq-field-label">');
-    questionLabel.append($('<span>').text(__('Treść pytania')));
-    const questionInput = $('<input type="text" class="wcrq-q regular-text">').val(question.question || '');
-    questionLabel.append(': ').append(questionInput);
-    questionRow.append(questionLabel);
-    wrapper.append(questionRow);
+  list.on('click', '.wcrq-preview', function (event) {
+    event.preventDefault();
+    renderPreview($(this).closest('.wcrq-question-item'));
+  });
 
-    const imageHolder = $('<div class="wcrq-image">');
-    if (question.image) {
-      imageHolder.append(
+  list.on('input change', '.wcrq-q, .wcrq-a, .wcrq-correct', function () {
+    $(this).closest('.wcrq-question-item').find('.wcrq-preview-area').hide();
+  });
+
+  list.on('change', '.wcrq-img', function () {
+    const wrapper = $(this).closest('.wcrq-question-item');
+    const url = $(this).val();
+    const preview = wrapper.find('.wcrq-image-preview');
+    preview.empty();
+    if (url) {
+      preview.append(
         $('<img>', {
-          src: question.image,
+          src: url,
           alt: '',
-          style: 'max-width:150px;height:auto;',
         }),
       );
     }
-    const imageButtons = $('<p class="wcrq-image-actions">');
-    const selectButton = $('<button type="button" class="button wcrq-select-image">').text(__('Wybierz grafikę'));
-    const removeButton = $('<button type="button" class="button wcrq-remove-image">').text(__('Usuń grafikę'));
-    imageButtons.append(selectButton).append(' ').append(removeButton);
-    const imageInput = $('<input type="hidden" class="wcrq-img">').val(question.image || '');
-    imageHolder.append(imageButtons).append(imageInput);
-    wrapper.append(imageHolder);
-
-    const answersWrapper = $('<div class="wcrq-answers">');
-    answersWrapper.append('<p><strong>' + __('Odpowiedzi') + '</strong></p>');
-    answers.forEach(function (answer, idx) {
-      const radioName = 'wcrq_correct_' + key;
-      const checked = parseInt(question.correct, 10) === idx ? 'checked' : '';
-      const label = $('<label class="wcrq-answer-row">');
-      const radio = $('<input type="radio">').attr({
-        name: radioName,
-        value: idx,
-      });
-      if (checked) {
-        radio.prop('checked', true);
-      }
-      const answerInput = $('<input type="text" class="wcrq-a regular-text">').val(answer || '');
-      label.append(radio).append(' ').append(answerInput);
-      answersWrapper.append($('<p>').append(label));
-    });
-    wrapper.append(answersWrapper);
-
-    wrapper.append(
-      '<p class="wcrq-question-actions"><button type="button" class="button wcrq-preview">' +
-        __('Podgląd') +
-        '</button> <button type="button" class="button button-link-delete wcrq-remove">' +
-        __('Usuń pytanie') +
-        '</button></p><div class="wcrq-preview-area" style="display:none;"></div>',
-    );
-
-    container.append(wrapper);
-  }
-
-  function render(existingQuestions) {
-    container.empty();
-    existingQuestions.forEach(function (question) {
-      renderQuestion(question);
-    });
-    collect();
-  }
-
-  container.on('click', '.wcrq-remove', function () {
-    $(this).closest('.wcrq-question').remove();
-    render(snapshotQuestions());
+    wrapper.find('.wcrq-preview-area').hide();
   });
 
-  container.on('input change', '.wcrq-q, .wcrq-a', collect);
-  container.on('change', 'input[type=radio]', collect);
-
-  container.on('click', '.wcrq-select-image', function (event) {
+  list.on('click', '.wcrq-remove-image', function (event) {
     event.preventDefault();
-    const holder = $(this).closest('.wcrq-image');
+    const wrapper = $(this).closest('.wcrq-question-item');
+    wrapper.find('.wcrq-img').val('');
+    wrapper.find('.wcrq-image-preview').empty();
+    wrapper.find('.wcrq-preview-area').hide();
+  });
+
+  list.on('click', '.wcrq-select-image', function (event) {
+    event.preventDefault();
+    const wrapper = $(this).closest('.wcrq-question-item');
 
     if (mediaFrame) {
       mediaFrame.close();
@@ -172,92 +238,29 @@ jQuery(function ($) {
 
     mediaFrame.on('select', function () {
       const attachment = mediaFrame.state().get('selection').first().toJSON();
-      holder.find('.wcrq-img').val(attachment.url);
-      holder.find('img').remove();
-      holder.prepend(
+      wrapper.find('.wcrq-img').val(attachment.url);
+      const preview = wrapper.find('.wcrq-image-preview');
+      preview.empty().append(
         $('<img>', {
           src: attachment.url,
           alt: '',
-          style: 'max-width:150px;height:auto;',
         }),
       );
-      collect();
+      wrapper.find('.wcrq-preview-area').hide();
     });
 
     mediaFrame.open();
   });
 
-  container.on('click', '.wcrq-remove-image', function (event) {
-    event.preventDefault();
-    const holder = $(this).closest('.wcrq-image');
-    holder.find('.wcrq-img').val('');
-    holder.find('img').remove();
-    collect();
-  });
-
-  container.on('click', '.wcrq-preview', function () {
-    const wrap = $(this).closest('.wcrq-question');
-    const data = getQuestionData(wrap);
-    const preview = wrap.find('.wcrq-preview-area');
-
-    let html = '';
-    if (data.question) {
-      html += '<p><strong>' + escapeHtml(data.question) + '</strong></p>';
-    }
-    if (data.image) {
-      html += '<p><img src="' + escapeHtml(data.image) + '" style="max-width:150px;height:auto;" alt="" /></p>';
-    }
-    data.answers.forEach(function (answer, index) {
-      if (!answer) {
-        return;
-      }
-      const mark = data.correct === index ? ' <em>(' + __('prawidłowa') + ')</em>' : '';
-      html += '<p><label><input type="radio" disabled> ' + escapeHtml(answer) + mark + '</label></p>';
-    });
-
-    preview.html(html || '<p>' + __('Brak danych do podglądu.') + '</p>');
-    preview.toggle();
-  });
+  if (!list.children('.wcrq-question-item').length) {
+    createQuestion(getBlankQuestion());
+  } else {
+    refreshIndices();
+  }
 
   if (form.length) {
-    form.on('submit', collect);
-  }
-
-  let existing = [];
-  try {
-    existing = JSON.parse(input.val());
-  } catch (error) {
-    existing = [];
-  }
-
-  if (!Array.isArray(existing)) {
-    existing = [];
-  }
-
-  existing = existing.map(function (question) {
-    question.key = nextKey();
-    question.answers = ensureAnswersArray(question.answers);
-    question.correct = typeof question.correct === 'number' ? question.correct : 0;
-    return question;
-  });
-
-  render(existing);
-
-  const addButton = $('<p><button type="button" class="button" id="wcrq_add_question"></button></p>');
-  addButton.find('button').text(__('Dodaj pytanie'));
-  container.after(addButton);
-
-  $(document).on('click', '#wcrq_add_question', function (event) {
-    event.preventDefault();
-    const questions = snapshotQuestions();
-    questions.push({
-      key: nextKey(),
-      question: '',
-      answers: ['', '', '', ''],
-      correct: 0,
-      image: '',
+    form.on('submit', function () {
+      list.find('.wcrq-preview-area').hide();
     });
-    render(questions);
-  });
+  }
 });
-


### PR DESCRIPTION
## Summary
- normalize stored quiz questions into sanitized arrays with helpers that preserve compatibility with existing JSON data
- rebuild the questions admin page with templated fieldsets, fallback markup, and dedicated styling for a clearer editing experience
- replace the legacy questions-builder script with a new jQuery implementation that manages add/remove actions, previews, and media attachments

## Testing
- php -l wcr-quiz.php

------
https://chatgpt.com/codex/tasks/task_e_68cad70d1940832093725ad37961a984