### PR TITLE
Fix quiz question management assets loading

### DIFF
--- a/wcr-quiz/wcr-quiz.php
+++ b/wcr-quiz/wcr-quiz.php
@@ -572,32 +572,39 @@ function wcrq_field_show_results() {
 }
 
 function wcrq_admin_scripts($hook) {
-    if ($hook === 'wcrq_page_wcrq_questions') {
-        // Media is required for adding images to questions
-        wp_enqueue_media();
-        wp_enqueue_style(
-            'wcrq-questions-admin',
-            plugins_url('assets/css/admin.css', __FILE__),
-            [],
-            '0.2'
-        );
-        wp_enqueue_script(
-            'wcrq-questions-admin',
-            plugins_url('assets/js/questions-admin.js', __FILE__),
-            [],
-            '0.1',
-            true
-        );
-        wp_localize_script(
-            'wcrq-questions-admin',
-            'wcrqQuestionsAdmin',
-            [
-                'chooseImage' => __('Wybierz obrazek', 'wcrq'),
-                'removeConfirmation' => __('Usunąć to pytanie?', 'wcrq'),
-                'minimumNotice' => __('Musisz zachować co najmniej jedno pytanie.', 'wcrq'),
-            ]
-        );
+    $question_hooks = [
+        'wcrq_page_wcrq_questions',
+        'wcrq_page_wcrq-questions',
+    ];
+
+    if (!in_array($hook, $question_hooks, true)) {
+        return;
     }
+
+    // Media is required for adding images to questions
+    wp_enqueue_media();
+    wp_enqueue_style(
+        'wcrq-questions-admin',
+        plugins_url('assets/css/admin.css', __FILE__),
+        [],
+        '0.2'
+    );
+    wp_enqueue_script(
+        'wcrq-questions-admin',
+        plugins_url('assets/js/questions-admin.js', __FILE__),
+        [],
+        '0.1',
+        true
+    );
+    wp_localize_script(
+        'wcrq-questions-admin',
+        'wcrqQuestionsAdmin',
+        [
+            'chooseImage' => __('Wybierz obrazek', 'wcrq'),
+            'removeConfirmation' => __('Usunąć to pytanie?', 'wcrq'),
+            'minimumNotice' => __('Musisz zachować co najmniej jedno pytanie.', 'wcrq'),
+        ]
+    );
 }
 add_action('admin_enqueue_scripts', 'wcrq_admin_scripts');
 


### PR DESCRIPTION
## Summary
- ensure the questions admin screen loads its JavaScript and CSS assets whether WordPress normalizes the submenu slug with an underscore or hyphen
- keep localized strings and media integration available so adding/removing quiz questions works correctly

## Testing
- php -l wcr-quiz/wcr-quiz.php

------
https://chatgpt.com/codex/tasks/task_e_68cb0e4cf69483209a06cc5118ffe41b