### PR TITLE
Improve quiz start behavior and update pre-quiz rules

### DIFF
--- a/wcr-quiz/assets/css/style.css
+++ b/wcr-quiz/assets/css/style.css
@@ -190,8 +190,20 @@
     color: #14532d;
 }
 
+.wcrq-pre-quiz-rules-block {
+    padding-top: 1rem;
+    font-size: 0.95rem;
+}
+
+.wcrq-pre-quiz-rules-title {
+    margin: 0 0 0.75rem;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #14532d;
+}
+
 .wcrq-pre-quiz-rules {
-    margin: 1.25rem 0 0;
+    margin: 0;
     padding-left: 1.5rem;
     color: #166534;
 }
@@ -200,17 +212,13 @@
     margin-bottom: 0.5rem;
 }
 
-.wcrq-pre-quiz-notice {
-    margin: 0 0 1.5rem;
-    padding: 0.75rem 1rem;
-    background: #fee2e2;
-    border-radius: 6px;
-    font-weight: 600;
-    color: #b91c1c;
-}
-
 .wcrq-start {
     padding-top: 0.5rem;
+    text-align: center;
+}
+
+.wcrq-start p {
+    margin: 0;
 }
 
 .wcrq-navigation-warning {

--- a/wcr-quiz/assets/js/countdown.js
+++ b/wcr-quiz/assets/js/countdown.js
@@ -31,6 +31,19 @@
       if(remaining <= 0){
         clearInterval(timer);
         el.classList.add('wcrq-countdown-finished');
+        var event;
+        if(typeof window.CustomEvent === 'function'){
+          event = new CustomEvent('wcrqCountdownFinished', { detail: { element: el } });
+        }else{
+          event = document.createEvent('Event');
+          event.initEvent('wcrqCountdownFinished', true, true);
+          event.detail = { element: el };
+        }
+        el.dispatchEvent(event);
+        document.dispatchEvent(event);
+        setTimeout(function(){
+          window.location.reload();
+        }, 1000);
         return;
       }
       remaining -= 1;

--- a/wcr-quiz/wcr-quiz.php
+++ b/wcr-quiz/wcr-quiz.php
@@ -991,23 +991,22 @@ function wcrq_quiz_shortcode() {
             }
             $rules = [];
             if ($show_violations_to_users) {
-                $rules[] = esc_html__('Opuszczanie quizu w trakcie jego trwania jest zabronione. Każde naruszenie zostanie zapisane.', 'wcrq');
+                $rules[] = esc_html__('Opuszczanie quizu w trakcie jego trwania jest zabronione. Każde naruszenie zostanie zapisane, a wyjście ze strony quizu zostanie odnotowane jako naruszenie.', 'wcrq');
             }
             if (!$allow_navigation) {
                 $rules[] = esc_html__('Nie można wracać do poprzednich pytań podczas rozwiązywania quizu.', 'wcrq');
             }
             if ($rules) {
+                $sections .= '<div class="wcrq-pre-quiz-rules-block">';
+                $sections .= '<h3 class="wcrq-pre-quiz-rules-title">' . esc_html__('Zasady podczas quizu:', 'wcrq') . '</h3>';
                 $sections .= '<ul class="wcrq-pre-quiz-rules">';
                 foreach ($rules as $rule) {
                     $sections .= '<li>' . $rule . '</li>';
                 }
                 $sections .= '</ul>';
+                $sections .= '</div>';
             }
             $sections .= '</div>';
-
-            if ($show_violations_to_users) {
-                $sections .= '<p class="wcrq-pre-quiz-notice">' . esc_html__('Wyjście ze strony quizu zostanie odnotowane jako naruszenie.', 'wcrq') . '</p>';
-            }
 
             return '<div class="wcrq-pre-quiz">' . $sections . '<form method="post" class="wcrq-start"><p><button type="submit" name="wcrq_start" value="1">' . __('Rozpocznij quiz', 'wcrq') . '</button></p></form></div>';
         }


### PR DESCRIPTION
## Summary
- trigger a page refresh automatically when the countdown reaches zero so the start panel appears without manual reload
- restructure the pre-quiz rules into a dedicated block with a heading, unified wording about leaving the quiz, and reduced font size
- center the "Rozpocznij quiz" button to improve presentation before starting the quiz

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc27c64e548320815bb13841ad9a05