### PR TITLE
Ensure quiz attempts persist and enforce answer selection

### DIFF
--- a/wcr-quiz/assets/css/style.css
+++ b/wcr-quiz/assets/css/style.css
@@ -141,6 +141,13 @@
     margin-bottom: 0.75rem;
 }
 
+.wcrq-question.is-error {
+    border: 2px solid #dc2626;
+    border-radius: 6px;
+    padding: 1rem;
+    background: #fef2f2;
+}
+
 .wcrq-question-nav {
     display: flex;
     gap: 1rem;
@@ -170,6 +177,17 @@
     max-width: 700px;
     margin: 2rem auto;
     font-family: Arial, sans-serif;
+}
+
+.wcrq-quiz-completed {
+    background: #f0fdf4;
+    border: 2px solid #16a34a;
+    border-radius: 8px;
+    padding: 2rem;
+    max-width: 700px;
+    margin: 2rem auto;
+    font-family: Arial, sans-serif;
+    text-align: center;
 }
 
 .wcrq-pre-quiz-section {

--- a/wcr-quiz/assets/js/quiz.js
+++ b/wcr-quiz/assets/js/quiz.js
@@ -78,6 +78,7 @@ document.addEventListener('DOMContentLoaded', function() {
   var warningBox = showViolationMessage ? form.querySelector('.wcrq-quiz-warning') : null;
   var violationCount = 0;
   var lastViolationAt = 0;
+  var requiredMessage = quizData.needAnswerMessage || '';
 
   function updateWarning(count) {
     violationCount = count;
@@ -209,6 +210,9 @@ document.addEventListener('DOMContentLoaded', function() {
     if (!tabs.length) return;
     var answered = !!questions[index].querySelector('input[type="radio"]:checked');
     tabs[index].classList.toggle('is-answered', answered);
+    if (answered) {
+      questions[index].classList.remove('is-error');
+    }
   }
 
   function setActive(index) {
@@ -219,6 +223,21 @@ document.addEventListener('DOMContentLoaded', function() {
     });
     syncTabState(index);
     updateButtons();
+  }
+
+  function ensureAnswered(index) {
+    if (index < 0 || index >= questions.length) {
+      return true;
+    }
+    if (questions[index].querySelector('input[type="radio"]:checked')) {
+      questions[index].classList.remove('is-error');
+      return true;
+    }
+    questions[index].classList.add('is-error');
+    if (requiredMessage) {
+      window.alert(requiredMessage);
+    }
+    return false;
   }
 
   questions.forEach(function(question, index) {
@@ -248,6 +267,9 @@ document.addEventListener('DOMContentLoaded', function() {
       tab.addEventListener('click', function() {
         var idx = parseInt(tab.dataset.index || '0', 10);
         if (!isNaN(idx)) {
+          if (idx > current && !ensureAnswered(current)) {
+            return;
+          }
           setActive(idx);
         }
       });
@@ -256,6 +278,9 @@ document.addEventListener('DOMContentLoaded', function() {
 
   if (nextBtn) {
     nextBtn.addEventListener('click', function() {
+      if (!ensureAnswered(current)) {
+        return;
+      }
       setActive(current + 1);
     });
   }


### PR DESCRIPTION
## Summary
- persist active quiz attempts by syncing stored results, auto-finalizing expired sessions, and blocking additional retries
- show Polish-formatted start times and restore saved answers when resuming a quiz
- require choosing an answer before moving forward and highlight unanswered questions in the UI

## Testing
- php -l wcr-quiz/wcr-quiz.php

------
https://chatgpt.com/codex/tasks/task_e_68cc2aec695c8320aacb1abeb8a9b473