### PR TITLE
Replace alert-based quiz validation with inline messaging

### DIFF
--- a/wcr-quiz/assets/css/style.css
+++ b/wcr-quiz/assets/css/style.css
@@ -148,6 +148,16 @@
     background: #fef2f2;
 }
 
+.wcrq-question-error-message {
+    color: #b91c1c;
+    font-weight: 600;
+    margin-top: 0.75rem;
+}
+
+.wcrq-question-error-message[hidden] {
+    display: none;
+}
+
 .wcrq-question-nav {
     display: flex;
     gap: 1rem;

--- a/wcr-quiz/assets/js/quiz.js
+++ b/wcr-quiz/assets/js/quiz.js
@@ -206,12 +206,52 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   }
 
+  function getQuestionErrorMessage(question) {
+    if (!question) {
+      return requiredMessage;
+    }
+    var message = question.dataset ? question.dataset.requiredMessage : '';
+    if (typeof message === 'string' && message.length) {
+      return message;
+    }
+    return requiredMessage;
+  }
+
+  function hideQuestionError(question) {
+    if (!question) {
+      return;
+    }
+    question.classList.remove('is-error');
+    var messageEl = question.querySelector('.wcrq-question-error-message');
+    if (messageEl) {
+      messageEl.textContent = '';
+      messageEl.setAttribute('hidden', 'hidden');
+    }
+  }
+
+  function showQuestionError(question) {
+    if (!question) {
+      return;
+    }
+    question.classList.add('is-error');
+    var messageEl = question.querySelector('.wcrq-question-error-message');
+    if (!messageEl) {
+      return;
+    }
+    messageEl.textContent = getQuestionErrorMessage(question);
+    messageEl.removeAttribute('hidden');
+  }
+
   function markAnswered(index) {
     if (!tabs.length) return;
-    var answered = !!questions[index].querySelector('input[type="radio"]:checked');
+    var question = questions[index];
+    if (!question) {
+      return;
+    }
+    var answered = !!question.querySelector('input[type="radio"]:checked');
     tabs[index].classList.toggle('is-answered', answered);
     if (answered) {
-      questions[index].classList.remove('is-error');
+      hideQuestionError(question);
     }
   }
 
@@ -229,14 +269,15 @@ document.addEventListener('DOMContentLoaded', function() {
     if (index < 0 || index >= questions.length) {
       return true;
     }
-    if (questions[index].querySelector('input[type="radio"]:checked')) {
-      questions[index].classList.remove('is-error');
+    var question = questions[index];
+    if (!question) {
       return true;
     }
-    questions[index].classList.add('is-error');
-    if (requiredMessage) {
-      window.alert(requiredMessage);
+    if (question.querySelector('input[type="radio"]:checked')) {
+      hideQuestionError(question);
+      return true;
     }
+    showQuestionError(question);
     return false;
   }
 

--- a/wcr-quiz/wcr-quiz.php
+++ b/wcr-quiz/wcr-quiz.php
@@ -1308,8 +1308,10 @@ function wcrq_quiz_shortcode() {
     }
     $out .= '</div>';
 
+    $required_message = esc_attr__('Zaznacz odpowiedź, zanim przejdziesz do kolejnego pytania.', 'wcrq');
+
     foreach ($questions as $idx => $q) {
-        $out .= '<div class="wcrq-question" data-index="' . intval($idx) . '" role="tabpanel">';
+        $out .= '<div class="wcrq-question" data-index="' . intval($idx) . '" role="tabpanel" data-required-message="' . $required_message . '">';
         $out .= '<p class="wcrq-question-title">' . esc_html($q['question']) . '</p>';
         if (!empty($q['image'])) {
             $out .= '<p><img src="' . esc_url($q['image']) . '" alt="" class="wcrq-question-image" /></p>';
@@ -1319,6 +1321,7 @@ function wcrq_quiz_shortcode() {
             $checked = (isset($saved_responses[$idx]) && intval($saved_responses[$idx]) === intval($a_idx)) ? ' checked' : '';
             $out .= '<label class="wcrq-answer"><input type="radio" name="' . esc_attr($name) . '" value="' . intval($a_idx) . '"' . $checked . '> ' . esc_html($answer) . '</label>';
         }
+        $out .= '<p class="wcrq-question-error-message" aria-live="polite" hidden></p>';
         $out .= '</div>';
     }
 


### PR DESCRIPTION
## Summary
- add inline error message containers to quiz questions and expose localized text via data attribute
- update quiz script to show and hide inline validation messages instead of triggering alerts
- style the validation message for better visibility

## Testing
- php -l wcr-quiz/wcr-quiz.php

------
https://chatgpt.com/codex/tasks/task_e_68cc346cc3a483209e32d85ebd3ec6cb