### PR TITLE
Add final question validation and stabilize quiz layout

### DIFF
--- a/wcr-quiz/assets/css/style.css
+++ b/wcr-quiz/assets/css/style.css
@@ -123,6 +123,13 @@
     font-size: 1.1rem;
 }
 
+.wcrq-question {
+    border: 2px solid transparent;
+    border-radius: 6px;
+    padding: 1rem;
+    transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
 .wcrq-quiz:not(.wcrq-no-js) .wcrq-question {
     display: none;
 }
@@ -142,9 +149,7 @@
 }
 
 .wcrq-question.is-error {
-    border: 2px solid #dc2626;
-    border-radius: 6px;
-    padding: 1rem;
+    border-color: #dc2626;
     background: #fef2f2;
 }
 

--- a/wcr-quiz/assets/js/quiz.js
+++ b/wcr-quiz/assets/js/quiz.js
@@ -281,6 +281,15 @@ document.addEventListener('DOMContentLoaded', function() {
     return false;
   }
 
+  function findFirstUnanswered() {
+    for (var i = 0; i < questions.length; i += 1) {
+      if (!ensureAnswered(i)) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
   questions.forEach(function(question, index) {
     question.addEventListener('change', function() {
       markAnswered(index);
@@ -325,6 +334,23 @@ document.addEventListener('DOMContentLoaded', function() {
       setActive(current + 1);
     });
   }
+
+  form.addEventListener('submit', function(event) {
+    if (form.dataset.submitted === '1') {
+      return;
+    }
+    var unansweredIndex = findFirstUnanswered();
+    if (unansweredIndex !== -1) {
+      event.preventDefault();
+      setActive(unansweredIndex);
+      var targetQuestion = questions[unansweredIndex];
+      if (targetQuestion && typeof targetQuestion.scrollIntoView === 'function') {
+        targetQuestion.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+      return;
+    }
+    form.dataset.submitted = '1';
+  });
 
   setActive(0);
 });


### PR DESCRIPTION
## Summary
- prevent quiz submissions until all questions have been answered and guide the user to the first unanswered entry
- mark unanswered questions via existing error messaging and remember once the form is submitted to avoid double submissions
- add a neutral border to quiz questions so showing validation feedback no longer shifts the layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc35f3f3808320888b1d51c0e5c0e3