### PR TITLE
Enforce single active quiz session per participant

### DIFF
--- a/wcr-quiz/assets/js/quiz.js
+++ b/wcr-quiz/assets/js/quiz.js
@@ -107,6 +107,18 @@ document.addEventListener('DOMContentLoaded', function() {
       method: 'POST',
       credentials: 'same-origin',
       body: formData
+    }).then(function(response) {
+      if (!response) {
+        return Promise.reject();
+      }
+      if (response.status === 409 || response.status === 403) {
+        window.location.reload();
+        return Promise.reject();
+      }
+      if (!response.ok) {
+        return Promise.reject();
+      }
+      return response;
     });
   }
 


### PR DESCRIPTION
## Summary
- add server-side helpers and database columns to track a participant's active quiz session and invalidate parallel logins
- harden quiz flow to require a fresh login after completion or conflicts, persist progress, and prevent navigating backwards after start
- surface AJAX session conflicts to the browser so abandoned sessions are automatically reloaded and progress continues safely

## Testing
- php -l wcr-quiz.php

------
https://chatgpt.com/codex/tasks/task_e_68cc37c797ac83209fbba9e3a173f65e