### PR TITLE
Fix duplicate login form and show inline error message

### DIFF
--- a/wcr-quiz/assets/css/style.css
+++ b/wcr-quiz/assets/css/style.css
@@ -49,6 +49,16 @@
     background: #15803d;
 }
 
+.wcrq-login-message {
+    background: #fef2f2;
+    border: 1px solid #dc2626;
+    border-radius: 4px;
+    color: #b91c1c;
+    font-weight: 600;
+    margin-bottom: 1.5rem;
+    padding: 0.75rem 1rem;
+}
+
 .wcrq-registration p {
     margin-bottom: 2rem;
 }


### PR DESCRIPTION
## Summary
- keep failed login messages in the session so the shortcode renders them inside the form
- prevent template_redirect handler from echoing an extra login form and place the alert directly in the form markup
- style the inline login error message for better visibility

## Testing
- php -l wcr-quiz/wcr-quiz.php

------
https://chatgpt.com/codex/tasks/task_e_68cc42ea21d48320894b1b1ad78b3358