### PR TITLE
Add admin result management controls and relogin button

### DIFF
--- a/wcr-quiz/assets/css/style.css
+++ b/wcr-quiz/assets/css/style.css
@@ -32,7 +32,8 @@
 .wcrq-registration button,
 .wcrq-login button,
 .wcrq-quiz button,
-.wcrq-start button {
+.wcrq-start button,
+.wcrq-completion-login-button {
     background: #16a34a;
     color: #fff;
     padding: 1rem 2rem;
@@ -45,8 +46,18 @@
 .wcrq-registration button:hover,
 .wcrq-login button:hover,
 .wcrq-quiz button:hover,
-.wcrq-start button:hover {
+.wcrq-start button:hover,
+.wcrq-completion-login-button:hover {
     background: #15803d;
+}
+
+.wcrq-relogin-block {
+    margin-top: 2rem;
+    text-align: center;
+}
+
+.wcrq-relogin-block .wcrq-login {
+    margin-top: 1.5rem;
 }
 
 .wcrq-login-message {

--- a/wcr-quiz/assets/js/completion.js
+++ b/wcr-quiz/assets/js/completion.js
@@ -1,0 +1,28 @@
+(function() {
+  function init() {
+    var button = document.querySelector('.wcrq-completion-login-button');
+    if (!button) {
+      return;
+    }
+    var container = document.querySelector('.wcrq-relogin-container');
+    if (!container) {
+      return;
+    }
+    button.addEventListener('click', function() {
+      if (container.hasAttribute('hidden')) {
+        container.removeAttribute('hidden');
+        button.setAttribute('disabled', 'disabled');
+        var input = container.querySelector('input[name="wcrq_login"]');
+        if (input) {
+          input.focus();
+        }
+      }
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## Summary
- add a relogin button and supporting script to the completion message so users can log in again immediately
- extend the results admin page with bulk clear confirmation, per-result deletion, and cleaner notices
- adjust CSV export output to be Excel-friendly by emitting a BOM and semicolon delimiters

## Testing
- php -l wcr-quiz/wcr-quiz.php

------
https://chatgpt.com/codex/tasks/task_e_68cc519778b083208113850b85834d97