### PR TITLE
Add modal confirmations for results deletion

### DIFF
--- a/wcr-quiz/assets/css/results-admin.css
+++ b/wcr-quiz/assets/css/results-admin.css
@@ -1,0 +1,79 @@
+.wcrq-modal {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 100000;
+    font-family: inherit;
+}
+
+.wcrq-modal[hidden] {
+    display: none;
+}
+
+.wcrq-modal__backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+}
+
+.wcrq-modal__dialog {
+    position: relative;
+    background: #fff;
+    padding: 24px;
+    border-radius: 8px;
+    box-shadow: 0 20px 55px rgba(0, 0, 0, 0.2);
+    max-width: 420px;
+    width: calc(100% - 40px);
+    z-index: 1;
+}
+
+.wcrq-modal__title {
+    margin: 0 0 12px;
+    font-size: 20px;
+    line-height: 1.3;
+}
+
+.wcrq-modal__body {
+    margin-bottom: 20px;
+    line-height: 1.5;
+}
+
+.wcrq-modal__prompt {
+    margin-top: 12px;
+}
+
+.wcrq-modal__prompt label {
+    display: block;
+    margin-bottom: 8px;
+    font-weight: 600;
+}
+
+.wcrq-modal__prompt input {
+    width: 100%;
+    padding: 8px 10px;
+    border: 1px solid #8c8f94;
+    border-radius: 4px;
+}
+
+.wcrq-modal__error {
+    color: #b32d2e;
+    margin-top: 8px;
+}
+
+.wcrq-modal__actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+}
+
+.wcrq-results-clear__description {
+    display: inline-block;
+    margin-right: 12px;
+}
+
+.noscript-wcrq-clear-warning {
+    margin-top: 8px;
+    color: #b32d2e;
+}

--- a/wcr-quiz/assets/js/results.js
+++ b/wcr-quiz/assets/js/results.js
@@ -1,0 +1,203 @@
+(function () {
+  'use strict';
+
+  function ready(fn) {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', fn);
+    } else {
+      fn();
+    }
+  }
+
+  function buildModal() {
+    var modal = document.createElement('div');
+    modal.className = 'wcrq-modal';
+    modal.setAttribute('hidden', 'hidden');
+    modal.innerHTML =
+      '<div class="wcrq-modal__backdrop" data-modal-close="true"></div>' +
+      '<div class="wcrq-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="wcrq-modal-title">' +
+      '  <h2 class="wcrq-modal__title" id="wcrq-modal-title"></h2>' +
+      '  <div class="wcrq-modal__body">' +
+      '    <p class="wcrq-modal__message"></p>' +
+      '    <div class="wcrq-modal__prompt" hidden>' +
+      '      <label class="wcrq-modal__prompt-label" for="wcrq-modal-input"></label>' +
+      '      <input type="text" id="wcrq-modal-input" autocomplete="off" />' +
+      '      <p class="wcrq-modal__error" role="alert"></p>' +
+      '    </div>' +
+      '  </div>' +
+      '  <div class="wcrq-modal__actions">' +
+      '    <button type="button" class="button button-secondary" data-modal-cancel="true"></button>' +
+      '    <button type="button" class="button button-primary" data-modal-confirm="true"></button>' +
+      '  </div>' +
+      '</div>';
+
+    document.body.appendChild(modal);
+    return modal;
+  }
+
+  function setupModal() {
+    var modal = document.querySelector('.wcrq-modal');
+    if (!modal) {
+      modal = buildModal();
+    }
+
+    var dialog = modal.querySelector('.wcrq-modal__dialog');
+    var titleEl = modal.querySelector('.wcrq-modal__title');
+    var messageEl = modal.querySelector('.wcrq-modal__message');
+    var promptEl = modal.querySelector('.wcrq-modal__prompt');
+    var promptLabel = modal.querySelector('.wcrq-modal__prompt-label');
+    var inputEl = modal.querySelector('#wcrq-modal-input');
+    var errorEl = modal.querySelector('.wcrq-modal__error');
+    var confirmButton = modal.querySelector('[data-modal-confirm]');
+    var cancelButton = modal.querySelector('[data-modal-cancel]');
+    var backdrop = modal.querySelector('[data-modal-close]');
+
+    var activeOptions = null;
+    var lastFocused = null;
+
+    function closeModal() {
+      modal.setAttribute('hidden', 'hidden');
+      dialog.setAttribute('aria-hidden', 'true');
+      errorEl.textContent = '';
+      inputEl.value = '';
+      activeOptions = null;
+      if (lastFocused && typeof lastFocused.focus === 'function') {
+        lastFocused.focus();
+      }
+    }
+
+    function openModal(options) {
+      activeOptions = options || {};
+      lastFocused = document.activeElement;
+      titleEl.textContent = activeOptions.title || '';
+      messageEl.textContent = activeOptions.message || '';
+      confirmButton.textContent = activeOptions.confirmLabel || 'OK';
+      cancelButton.textContent = activeOptions.cancelLabel || 'Anuluj';
+      errorEl.textContent = '';
+      inputEl.value = '';
+
+      if (activeOptions.prompt) {
+        promptEl.hidden = false;
+        promptLabel.textContent = activeOptions.prompt.label || '';
+        inputEl.placeholder = activeOptions.prompt.placeholder || '';
+      } else {
+        promptEl.hidden = true;
+      }
+
+      modal.removeAttribute('hidden');
+      dialog.removeAttribute('aria-hidden');
+      window.setTimeout(function () {
+        if (activeOptions.prompt) {
+          inputEl.focus();
+        } else {
+          confirmButton.focus();
+        }
+      }, 50);
+    }
+
+    function handleConfirm() {
+      if (!activeOptions) {
+        return;
+      }
+
+      if (activeOptions.prompt) {
+        var value = inputEl.value.trim();
+        if (activeOptions.prompt.validate && !activeOptions.prompt.validate(value)) {
+          errorEl.textContent = activeOptions.prompt.errorMessage || '';
+          inputEl.focus();
+          inputEl.select();
+          return;
+        }
+        if (typeof activeOptions.onConfirm === 'function') {
+          activeOptions.onConfirm(value);
+        }
+      } else if (typeof activeOptions.onConfirm === 'function') {
+        activeOptions.onConfirm();
+      }
+
+      closeModal();
+    }
+
+    function handleCancel() {
+      closeModal();
+      if (activeOptions && typeof activeOptions.onCancel === 'function') {
+        activeOptions.onCancel();
+      }
+    }
+
+    confirmButton.addEventListener('click', handleConfirm);
+    cancelButton.addEventListener('click', handleCancel);
+    backdrop.addEventListener('click', handleCancel);
+
+    modal.addEventListener('keydown', function (event) {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        handleCancel();
+      }
+    });
+
+    return openModal;
+  }
+
+  function init() {
+    var openModal = setupModal();
+    if (!openModal) {
+      return;
+    }
+
+    var deleteLinks = document.querySelectorAll('.wcrq-result-delete');
+    deleteLinks.forEach(function (link) {
+      link.addEventListener('click', function (event) {
+        event.preventDefault();
+        var title = link.getAttribute('data-confirm-title') || '';
+        var message = link.getAttribute('data-confirm-message') || '';
+        openModal({
+          title: title,
+          message: message,
+          confirmLabel: link.textContent.trim() || 'Usuń',
+          cancelLabel: 'Anuluj',
+          onConfirm: function () {
+            window.location.href = link.href;
+          },
+        });
+      });
+    });
+
+    var clearForm = document.querySelector('.wcrq-results-clear');
+    if (clearForm) {
+      var hiddenInput = clearForm.querySelector('.wcrq-results-clear__value');
+      var submitButton = clearForm.querySelector('[type="submit"], button[type="submit"]');
+      if (submitButton) {
+        submitButton.addEventListener('click', function (event) {
+          event.preventDefault();
+          var title = clearForm.getAttribute('data-confirm-title') || '';
+          var message = clearForm.getAttribute('data-confirm-message') || '';
+          var promptLabel = clearForm.getAttribute('data-prompt-label') || 'Wynik równania 1+2';
+          var promptError = clearForm.getAttribute('data-prompt-error') || 'Nieprawidłowy wynik. Spróbuj ponownie.';
+          openModal({
+            title: title,
+            message: message,
+            confirmLabel: submitButton.textContent.trim() || 'Usuń',
+            cancelLabel: 'Anuluj',
+            prompt: {
+              label: promptLabel,
+              placeholder: '',
+              errorMessage: promptError,
+              validate: function (value) {
+                return value === '3';
+              },
+            },
+            onConfirm: function (value) {
+              if (hiddenInput) {
+                hiddenInput.value = value;
+              }
+              clearForm.submit();
+            },
+          });
+        });
+      }
+    }
+  }
+
+  ready(init);
+})();


### PR DESCRIPTION
## Summary
- replace inline confirm prompts for results deletion with custom modal dialogs
- add admin assets to handle modal interactions and styles on the results page
- require solving 1+2 challenge inside the modal before clearing all results, accepting "3"

## Testing
- php -l wcr-quiz/wcr-quiz.php

------
https://chatgpt.com/codex/tasks/task_e_68cc54d6383c83209e2b8a8b6cfc511b