### PR TITLE
Fix results clearing form submission

### DIFF
--- a/wcr-quiz/assets/js/results.js
+++ b/wcr-quiz/assets/js/results.js
@@ -191,7 +191,11 @@
               if (hiddenInput) {
                 hiddenInput.value = value;
               }
-              clearForm.submit();
+              if (typeof clearForm.submit === 'function') {
+                clearForm.submit();
+              } else {
+                HTMLFormElement.prototype.submit.call(clearForm);
+              }
             },
           });
         });


### PR DESCRIPTION
## Summary
- ensure the clear results modal uses the form's native submit method even when a submit control shadows it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc5faa9b6c8320840b3a1f20907a7f