### PR TITLE
Lock answered quiz questions and update completion CTA

### DIFF
--- a/wcr-quiz/assets/css/style.css
+++ b/wcr-quiz/assets/css/style.css
@@ -33,7 +33,7 @@
 .wcrq-login button,
 .wcrq-quiz button,
 .wcrq-start button,
-.wcrq-completion-login-button {
+.wcrq-completion-close-button {
     background: #16a34a;
     color: #fff;
     padding: 1rem 2rem;
@@ -47,17 +47,27 @@
 .wcrq-login button:hover,
 .wcrq-quiz button:hover,
 .wcrq-start button:hover,
-.wcrq-completion-login-button:hover {
+.wcrq-completion-close-button:hover {
     background: #15803d;
 }
 
-.wcrq-relogin-block {
+.wcrq-completion-close-button {
+    display: inline-block;
+    text-decoration: none;
+    text-align: center;
+}
+
+.wcrq-completion-actions {
     margin-top: 2rem;
     text-align: center;
 }
 
-.wcrq-relogin-block .wcrq-login {
-    margin-top: 1.5rem;
+.wcrq-question-locked .wcrq-answer {
+    cursor: not-allowed;
+}
+
+.wcrq-question-locked input[type="radio"] {
+    pointer-events: none;
 }
 
 .wcrq-login-message {


### PR DESCRIPTION
## Summary
- disable quiz answers after the first selection using front-end locking and server-side safeguards
- persist locked answer state across refreshes and reuse saved responses when finalizing results
- replace the post-quiz login prompt with a Zamknij action that leads back to the quiz start and update related styles

## Testing
- php -l wcr-quiz/wcr-quiz.php

------
https://chatgpt.com/codex/tasks/task_e_68cc63f59dac83209ba99cc5ae2181bb