### PR TITLE
Increase session polling responsiveness

### DIFF
--- a/wcr-quiz/assets/js/quiz.js
+++ b/wcr-quiz/assets/js/quiz.js
@@ -376,6 +376,22 @@ document.addEventListener('DOMContentLoaded', function() {
     setInterval(checkSession, sessionCheckInterval * 1000);
   }
 
+  if (sessionNonce) {
+    var triggerSessionCheck = function() {
+      checkSession().catch(function() {
+        return null;
+      });
+    };
+
+    window.addEventListener('focus', triggerSessionCheck);
+
+    document.addEventListener('visibilitychange', function() {
+      if (!document.hidden) {
+        triggerSessionCheck();
+      }
+    });
+  }
+
   if (allowNavigation) {
     if (prevBtn) {
       prevBtn.addEventListener('click', function() {

--- a/wcr-quiz/wcr-quiz.php
+++ b/wcr-quiz/wcr-quiz.php
@@ -1624,7 +1624,7 @@ function wcrq_quiz_shortcode() {
         'showViolationMessage' => $show_violations_to_users ? 1 : 0,
         'trackViolations' => 1,
         'needAnswerMessage' => esc_html__('Zaznacz odpowiedź, zanim przejdziesz do kolejnego pytania.', 'wcrq'),
-        'sessionCheckInterval' => 15,
+        'sessionCheckInterval' => 5,
     ]);
 
     $out = '<form method="post" class="wcrq-quiz wcrq-no-js" data-duration="' . intval($remaining) . '" data-allow-navigation="' . ($allow_navigation ? '1' : '0') . '" data-start-timestamp="' . intval($start_timestamp) . '" data-end-timestamp="' . intval($end_timestamp) . '" data-server-now="' . intval($now) . '" data-current-question="' . intval($current_question) . '">';


### PR DESCRIPTION
## Summary
- reduce the localized session polling interval so the quiz checks with the backend more frequently
- trigger session validation when the browser tab regains focus or visibility to immediately detect expired sessions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ccfa7cc4088320a47a9fb895eb6bd7